### PR TITLE
Add LiveScoreProvider protocol to decouple matching/view from LiveTennisClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,31 @@ own code can focus on whatever decisions it makes. Everything downstream of
 the `LiveMarketView` (signals, execution, risk) is yours to build, with
 Polymarket's own official interfaces, and none of it lives here.
 
+### Swap in a different live-score source
+
+The matching and view code operates on plain dicts, never on a client, so the
+only place the pipeline touches a live-score source is a small four-method
+surface captured by the `LiveScoreProvider` protocol: `live_matches()`,
+`matches()`, `fixtures()`, and `match(match_id)`. `LiveTennisClient` is the
+default implementation and satisfies it out of the box; to feed the matcher and
+view from somewhere else, implement those four methods (returning dicts in the
+same shape — `players.p1.name`/`players.p2.name`, `score`, `status`, `id`) and
+hand your object to the same `_load_candidates`/`_decide` helpers. A worked,
+network-free implementation ships as `StaticLiveScoreProvider`, which the
+offline tests use:
+
+```python
+from polymarket_tennis import StaticLiveScoreProvider, match_market
+from polymarket_tennis.cli import _load_candidates
+
+provider = StaticLiveScoreProvider(live=[...], fixtures=[...])  # your own dicts
+decision = match_market(market, _load_candidates(provider))
+```
+
+This keeps `match_market()` and `build_view()` independent of any one provider
+and makes offline testing a matter of preloading a few dicts — no key, no
+network. (Thanks to #1 and #2 for raising the coupling.)
+
 ### Free-tier budget math (honest numbers)
 
 The Live Tennis API free tier allows **30 requests/minute and 100

--- a/src/polymarket_tennis/__init__.py
+++ b/src/polymarket_tennis/__init__.py
@@ -11,12 +11,15 @@ from .join import LiveMarketView, build_view, derive_break_point, score_line
 from .livetennis import LiveTennisClient
 from .matching import MatchDecision, extract_market_players, match_market
 from .models import TennisMarket
+from .providers import LiveScoreProvider, StaticLiveScoreProvider
 
 __version__ = "0.1.0"
 
 __all__ = [
     "GammaClient",
     "LiveTennisClient",
+    "LiveScoreProvider",
+    "StaticLiveScoreProvider",
     "TennisMarket",
     "MatchDecision",
     "LiveMarketView",

--- a/src/polymarket_tennis/cli.py
+++ b/src/polymarket_tennis/cli.py
@@ -34,6 +34,7 @@ from .join import build_view
 from .livetennis import LiveTennisClient, MissingAPIKeyError
 from .matching import MatchDecision, match_market, score_candidates
 from .models import TennisMarket
+from .providers import LiveScoreProvider
 
 MIN_INTERVAL = 30.0  # seconds; keeps polling polite on every tier
 
@@ -78,7 +79,7 @@ def _load_market(id_or_slug: str) -> TennisMarket | None:
         return find_market(gamma, id_or_slug)
 
 
-def _load_candidates(lta: LiveTennisClient) -> list[dict[str, Any]]:
+def _load_candidates(lta: LiveScoreProvider) -> list[dict[str, Any]]:
     candidates: list[dict[str, Any]] = list(lta.live_matches())
     candidates.extend(lta.matches(status="upcoming"))
     candidates.extend(lta.fixtures())
@@ -87,7 +88,7 @@ def _load_candidates(lta: LiveTennisClient) -> list[dict[str, Any]]:
 
 def _decide(
     market: TennisMarket,
-    lta: LiveTennisClient,
+    lta: LiveScoreProvider,
     override: int | None,
 ) -> tuple[MatchDecision | None, list[dict[str, Any]]]:
     candidates = _load_candidates(lta)

--- a/src/polymarket_tennis/providers.py
+++ b/src/polymarket_tennis/providers.py
@@ -1,0 +1,104 @@
+"""Live-score provider interface for the matching and view pipeline.
+
+The market -> match pipeline needs only a small slice of live-score access:
+list the live matches, list upcoming/fixture candidates, and fetch one match by
+id. ``LiveScoreProvider`` captures exactly that slice, so the matching and view
+logic depends on the interface rather than on the concrete
+:class:`~polymarket_tennis.livetennis.LiveTennisClient`.
+
+Why this exists (see issues #1 and #2): the matcher (``matching.py``) and the
+joined view (``join.py``) already operate on plain dicts, never on the client;
+this protocol makes that boundary explicit at the orchestration layer too. The
+practical payoffs are a swappable live-score source and offline tests that need
+no network and no key.
+
+``LiveTennisClient`` is the default implementation and satisfies this protocol
+structurally — nothing about it changes. To plug in a different source, provide
+an object with the four methods below returning dicts in the Live Tennis API
+shape the pipeline already consumes (``players.p1.name``/``players.p2.name``,
+``score``, ``status``, ``id``, ...); ``tests/fixtures`` are concrete examples,
+and :class:`StaticLiveScoreProvider` is a worked, network-free implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+__all__ = ["LiveScoreProvider", "StaticLiveScoreProvider"]
+
+
+@runtime_checkable
+class LiveScoreProvider(Protocol):
+    """The live-score surface the ``pmtennis`` pipeline depends on.
+
+    Implement these four methods to feed the matcher and view from a source
+    other than the Live Tennis API. Each returns plain dicts (or ``None`` for a
+    missing single match) — never provider-specific objects — so the matching
+    and view code stays unchanged.
+    """
+
+    def live_matches(self, tour: str | None = None) -> list[dict[str, Any]]:
+        """Matches currently in play, optionally filtered to one tour."""
+        ...
+
+    def matches(
+        self,
+        status: str = "live",
+        tour: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """Matches by lifecycle status (the pipeline asks for ``upcoming``)."""
+        ...
+
+    def fixtures(self, limit: int = 50, offset: int = 0) -> list[dict[str, Any]]:
+        """Scheduled fixtures used as additional match candidates."""
+        ...
+
+    def match(self, match_id: int) -> dict[str, Any] | None:
+        """One match by id, or ``None`` if the source no longer lists it."""
+        ...
+
+
+class StaticLiveScoreProvider:
+    """An in-memory :class:`LiveScoreProvider` backed by preloaded lists.
+
+    A worked example of implementing the protocol with no network access, and
+    the provider the offline tests use. It serves the lists it is handed and
+    resolves :meth:`match` by scanning them for a matching ``id``.
+    """
+
+    def __init__(
+        self,
+        live: list[dict[str, Any]] | None = None,
+        upcoming: list[dict[str, Any]] | None = None,
+        fixtures: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self._live = list(live or [])
+        self._upcoming = list(upcoming or [])
+        self._fixtures = list(fixtures or [])
+
+    def live_matches(self, tour: str | None = None) -> list[dict[str, Any]]:
+        return [m for m in self._live if tour is None or m.get("tour") == tour]
+
+    def matches(
+        self,
+        status: str = "live",
+        tour: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        pool = {"live": self._live, "upcoming": self._upcoming}.get(status, [])
+        if tour is not None:
+            pool = [m for m in pool if m.get("tour") == tour]
+        return pool[offset : offset + limit]
+
+    def fixtures(self, limit: int = 50, offset: int = 0) -> list[dict[str, Any]]:
+        return self._fixtures[offset : offset + limit]
+
+    def match(self, match_id: int) -> dict[str, Any] | None:
+        for pool in (self._live, self._upcoming, self._fixtures):
+            for candidate in pool:
+                if candidate.get("id") == match_id:
+                    return candidate
+        return None

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,46 @@
+"""LiveScoreProvider protocol: the default client satisfies it, and the whole
+decide path runs offline through a StaticLiveScoreProvider — no network, no key.
+"""
+
+from __future__ import annotations
+
+from polymarket_tennis.cli import _decide, _load_candidates
+from polymarket_tennis.livetennis import LiveTennisClient
+from polymarket_tennis.providers import LiveScoreProvider, StaticLiveScoreProvider
+
+from .test_matching import market_from
+
+
+def test_livetennisclient_satisfies_protocol():
+    # the default implementation must conform to the interface the pipeline
+    # depends on, so it stays swappable without a signature drift going unnoticed
+    assert isinstance(LiveTennisClient(api_key="x"), LiveScoreProvider)
+
+
+def test_static_provider_satisfies_protocol():
+    assert isinstance(StaticLiveScoreProvider(), LiveScoreProvider)
+
+
+def test_static_provider_serves_and_resolves(lta_live, lta_fixtures_payload):
+    provider = StaticLiveScoreProvider(
+        live=lta_live["data"], fixtures=lta_fixtures_payload["data"]
+    )
+    candidates = _load_candidates(provider)
+    assert candidates  # live + fixtures flattened
+    first_id = lta_live["data"][0]["id"]
+    assert provider.match(first_id) is not None
+    assert provider.match(-1) is None
+
+
+def test_decide_runs_fully_offline(gamma_events, lta_live, lta_fixtures_payload):
+    # the matcher already takes plain dicts; this proves the CLI orchestration
+    # helpers accept any LiveScoreProvider, so pairing works with zero network
+    market = market_from(gamma_events, "atp-lehecka-fils-2026-08-17")
+    provider = StaticLiveScoreProvider(
+        live=lta_live["data"], fixtures=lta_fixtures_payload["data"]
+    )
+    decision, candidates = _decide(market, provider, override=None)
+    assert candidates
+    assert decision is not None
+    assert decision.match_id is not None
+    assert decision.confidence >= 0.70


### PR DESCRIPTION
## What

Adds a small `LiveScoreProvider` protocol so the market → match pipeline depends on an interface rather than the concrete `LiveTennisClient`, exactly as proposed in #2 (and answering the provider-coupling question in #1).

The key observation: `matching.py` and `join.py` already operate on plain dicts, never on the client — the only coupling to `LiveTennisClient` lived at the CLI orchestration layer. This change makes that boundary explicit without altering any default behavior.

## Changes

- **New `providers.py`** — `LiveScoreProvider`, a `runtime_checkable` `Protocol` over the four methods the pipeline actually uses (`live_matches`, `matches`, `fixtures`, `match`), plus `StaticLiveScoreProvider`, a network-free reference implementation used by the offline tests.
- **`LiveTennisClient` satisfies the protocol structurally** — it is unchanged and stays the default. `cli.py`'s `_load_candidates` / `_decide` are retyped from `LiveTennisClient` to `LiveScoreProvider`.
- **Exports** `LiveScoreProvider` and `StaticLiveScoreProvider` from the package root.
- **Tests** (`tests/test_providers.py`): the default client conforms to the protocol; and the full `_decide` path runs entirely offline through `StaticLiveScoreProvider` built from the existing fixtures — no key, no network.
- **README** gains a "Swap in a different live-score source" section documenting how to implement the interface.

## Acceptance criteria (from #2)

- [x] Documented `LiveScoreProvider` protocol/interface
- [x] `LiveTennisClient` satisfies that interface
- [x] Matching/view code depends on the interface where practical (the CLI helpers; `matching.py`/`join.py` were already provider-agnostic)
- [x] Existing `pmtennis` CLI behavior unchanged
- [x] Existing tests continue to pass
- [x] At least one offline test using a mock/fixture provider
- [x] Documented how another provider could implement the interface

No order execution, wallet handling, or trading functionality added — observe-only, as before.

## Verification

`ruff check src tests` clean; full `pytest` green (98 passed), including the 4 new provider tests.
